### PR TITLE
Initial Code

### DIFF
--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -249,11 +249,15 @@ class FONA:
     @property
     def gprs(self):
         """Returns module's GPRS state."""
+        self._read_line()
         if self._debug:
             print("* Check GPRS State")
+
         if not self._send_parse_reply(b"AT+CGATT?", b"+CGATT: ", ":"):
             return False
-        return self._buf
+        if not self._buf:
+            return False
+        return True
 
     # pylint: disable=too-many-return-statements
     def set_gprs(self, apn=None, enable=True):

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -228,7 +228,7 @@ class FONA:
             print("\t---> AT+CIFSR")
 
         self._uart.write(b"AT+CIFSR\r\n")
-        print(self._buf)
+        self._read_line()
         return self.pretty_ip(self._buf)
 
     @property

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -229,7 +229,11 @@ class FONA:
 
         self._uart.write(b"AT+CIFSR\r\n")
         self._read_line()
-        return self.pretty_ip(self._buf)
+        try:
+            ip = self.pretty_ip(self._buf)
+        except:
+            return False
+        return ip
 
     @property
     def iccid(self):

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -344,6 +344,10 @@ class FONA:
             if not self._send_check_reply(b"AT+CIICR", reply=REPLY_OK, timeout=10000):
                 return False
 
+            # Query local IP
+            if not self.local_ip:
+                return False
+
         else:
             if self._debug:
                 print("* Disabling GPRS...")

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -241,9 +241,9 @@ class FONA:
         if self._debug:
             print("\t---> AT+CCID: ")
         self._uart.write(b"AT+CCID\r\n")
-        self._read_line(timeout=2000) #6.2.23, 2sec max. response time
+        self._read_line(timeout=2000)  # 6.2.23, 2sec max. response time
         iccid = self._buf.decode()
-        self._read_line() # eat 'OK'
+        self._read_line()  # eat 'OK'
         return iccid
 
     @property
@@ -433,7 +433,6 @@ class FONA:
                 "FONA 808 v1 not currently supported by this library."
             )
         return status
-
 
     @gps.setter
     def gps(self, gps_on=False):

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -150,8 +150,6 @@ class FONA:
             # determine if SIM800H
             self.uart_write(b"AT+GMM\r\n")
             self._read_line(multiline=True)
-            if self._debug:
-                print("\t <---", self._buf)
 
             if self._buf.find(b"SIM800H") != -1:
                 self._fona_type = FONA_800_H
@@ -287,8 +285,6 @@ class FONA:
             )
 
             # send AT+CSTT,"apn","user","pass"
-            if self._debug:
-                print("setting APN...")
             self._uart.reset_input_buffer()
 
             self.uart_write(b'AT+CSTT="' + apn_name)
@@ -481,8 +477,6 @@ class FONA:
         while not self._parse_reply(b"+CDNSGIP:", idx=2):
             self._read_line()
 
-        if self._debug:
-            print("\t<--- ", self._buf)
         return self._buf
 
     def pretty_ip(self, ip):  # pylint: disable=no-self-use, invalid-name
@@ -519,7 +513,7 @@ class FONA:
         for _ in range(allocated_socket, FONA_MAX_SOCKETS):
             self._read_line(100)
         if self._debug:
-            print("Allocated socket #%d"%allocated_socket)
+            print("Allocated socket #%d" % allocated_socket)
         return allocated_socket
 
     def remote_ip(self, sock_num):
@@ -535,8 +529,6 @@ class FONA:
         self._read_line(100)
 
         self._parse_reply(b"+CIPSTATUS:", idx=3)
-        if self._debug:
-            print("\t<--- ", self._buf)
         return self._buf
 
     def socket_status(self, sock_num):
@@ -553,8 +545,6 @@ class FONA:
 
         # eat the 'STATE: ' message
         self._read_line()
-        if self._debug:
-            print("\t<--- ", self._buf)
 
         # read "C: <n>" for each active connection
         for state in range(0, sock_num + 1):
@@ -718,18 +708,12 @@ class FONA:
         self.uart_write(b"\r\n")
         self._read_line()
 
-        if self._debug:
-            print("\t<--- ", self._buf)
-
         if self._buf[0] != 62:
             # promoting mark ('>') not found
             return False
 
         self.uart_write(buffer + b"\r\n")
         self._read_line(3000)
-
-        if self._debug:
-            print("\t<--- ", self._buf)
 
         if "SEND OK" not in self._buf.decode():
             return False
@@ -744,14 +728,9 @@ class FONA:
         :param bytes buffer: Buffer of bytes to send to the bus.
 
         """
-        #out_buffer_str = ", ".join([hex(i) for i in buffer])
         if self._debug:
             print("\tUARTWRITE ::", buffer.decode())
         self._uart.write(buffer)
-
-    def uart_read(self):
-        # TODO!
-        pass
 
     def _send_parse_reply(self, send_data, reply_data, divider=",", idx=0):
         """Sends data to FONA module, parses reply data returned.
@@ -782,9 +761,6 @@ class FONA:
             self.uart_write(prefix + suffix + b"\r\n")
 
         line = self._read_line(timeout)
-
-        if self._debug:
-            print("\t<--- ", self._buf)
         return line
 
     def _parse_reply(self, reply, divider=",", idx=0):
@@ -813,7 +789,8 @@ class FONA:
         return True
 
     def _read_line(self, timeout=FONA_DEFAULT_TIMEOUT_MS, multiline=False):
-        """Reads one or multiple lines into the buffer.
+        """Reads one or multiple lines into the buffer. Optionally prints the buffer
+        after reading.
         :param int timeout: Time to wait for UART serial to reply, in seconds.
         :param bool multiline: Read multiple lines.
 
@@ -847,6 +824,9 @@ class FONA:
                 break
             timeout -= 1
             time.sleep(0.001)
+
+        if self._debug:
+            print("\tUARTREAD ::", self._buf.decode())
 
         return reply_idx
 
@@ -909,9 +889,6 @@ class FONA:
         self.uart_write(suffix + b'"\r\n')
 
         line = self._read_line(timeout)
-        if self._debug:
-            print("\t<--- ", self._buf)
-
         return line
 
     def _expect_reply(self, reply, timeout=10000):
@@ -920,8 +897,6 @@ class FONA:
 
         """
         self._read_line(timeout)
-        if self._debug:
-            print("\t<--- ", self._buf)
         if reply not in self._buf:
             return False
         return True

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -223,17 +223,17 @@ class FONA:
 
     @property
     def local_ip(self):
-        """Returns the local IP Address."""
+        """Returns the local IP Address, False if not set."""
         if self._debug:
             print("\t---> AT+CIFSR")
 
         self._uart.write(b"AT+CIFSR\r\n")
         self._read_line()
         try:
-            ip = self.pretty_ip(self._buf)
-        except:
+            ip_addr = self.pretty_ip(self._buf)
+        except ValueError:
             return False
-        return ip
+        return ip_addr
 
     @property
     def iccid(self):
@@ -261,7 +261,7 @@ class FONA:
 
     # pylint: disable=too-many-return-statements
     def set_gprs(self, apn=None, enable=True):
-        """Sets and configures GPRS. 
+        """Configures and brings up GPRS.
         :param bool enable: Enables or disables GPRS.
 
         """

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -71,7 +71,7 @@ FONA_MAX_SOCKETS = const(6)
 
 # pylint: enable=bad-whitespace
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-public-methods
 class FONA:
     """CircuitPython FONA module interface.
     :param ~busio.uart UART: FONA UART connection.
@@ -148,10 +148,20 @@ class FONA:
         if self._debug:
             print("\t---> AT+CCID: ")
         self._uart.write(b"AT+CCID\r\n")
-        self._read_line(timeout=2000) #6.2.23, 2sec max. response time
+        self._read_line(timeout=2000)  # 6.2.23, 2sec max. response time
         iccid = self._buf.decode()
-        self._read_line() # eat 'OK'
+        self._read_line()  # eat 'OK'
         return iccid
+
+    def factory_reset(self):
+        """Resets modem to factory configuration."""
+        if self._debug:
+            print("\t---> ATZ")
+        self._uart.write(b"ATZ\r\n")
+
+        if not self._expect_reply(REPLY_OK):
+            return False
+        return True
 
     def pretty_ip(self, ip):  # pylint: disable=no-self-use, invalid-name
         """Converts a bytearray IP address to a dotted-quad string for printing"""
@@ -236,7 +246,6 @@ class FONA:
             if self._buf.find(b"SIM800H") != -1:
                 self._fona_type = FONA_800_H
         return True
-
 
     @property
     def gprs(self):

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -76,8 +76,17 @@ class GSM:
         if not self._iface.local_ip:
             raise RuntimeError("Unable to obtain module IP address.")
 
-    def network_attached(self):
-        """Returns if modem is attached to cellular network."""
-        # TODO!
+    @property
+    def is_connected(self):
+        """Returns if attached to GPRS and an IP Addresss was obtained.
+        """
+        if not self._iface.gprs and self._iface.local_ip:
+            return False
+        return True
+
+    def connect(self):
+        """Connect to GPRS network
+        """
+        # TODO
         pass
 

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -46,24 +46,8 @@ class GSM:
         self._apn = apn
         self._gsm_connected = False
 
-        # Attempt to enable GPS module and obtain GPS fix
-        attempts = 10
+        # Enable GPS module
         self._iface.gps = True
-        while not self._iface.gps == 3:
-            if attempts < 0:
-                raise RuntimeError("Unable to establish GPS fix.")
-            attempts -= 1
-            time.sleep(0.5)
-
-        # Check if FONA is registered to GSM network
-        attempts = 30
-        while self._iface.network_status != 1:
-            if attempts == 0:
-                raise TimeoutError("Not registered with GSM network.")
-            if self._debug:
-                print("* Not registered with network, retrying, ", attempts)
-            attempts -= 1
-            time.sleep(1)
 
     def __enter__(self):
         return self
@@ -80,6 +64,16 @@ class GSM:
     def iccid(self):
         """Returns the SIM card's ICCID, as a string."""
         return self._iface.iccid
+
+    @property
+    def is_attached(self):
+        """Returns if the modem is attached to the network
+        and the GPS has a fix."""
+        if self._iface.gps == 3:
+            if self._iface.network_status == 1:
+                return True
+        return False
+
 
     @property
     def is_connected(self):

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -1,0 +1,66 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Brent Rubell for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_fona_gsm`
+=================================================================================
+
+Interface for 2G GSM cellular modems such as the Adafruit FONA808.
+
+* Author(s): Brent Rubell
+
+"""
+import time
+
+class GSM:
+    def __init__(self, fona, apn):
+        """Initializes interface with 2G GSM modem.
+        :param adafruit_fona fona: Adafruit FONA module. 
+        :param tuple apn: Tuple containing APN name, (optional) APN username,
+                            and APN password.
+
+        """
+        self._iface = fona
+        # Attempt to enable GPS module and obtain GPS fix
+        self._iface.gps = True
+
+        attempts = 10
+        while not self._iface.gps == 3:
+            if attempts < 0:
+                raise RuntimeError("Unable to establish GPS fix.")
+            attempts -= 1
+
+        # Set GPRS
+        self._iface.gprs(True, apn)
+        attempts = 5
+
+        while not self.gprs(apn, True):
+            if attempts == 0:
+                raise RuntimeError("Unable to establish PDP context.")
+            if self._debug:
+                print("* Unable to bringup network, retrying, ", attempts)
+            self._iface.gprs(apn, False)
+            attempts -= 1
+            time.sleep(5)
+
+    def network_attached(self):
+        """Returns if modem is attached to cellular network."""
+

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -33,16 +33,14 @@ import time
 class GSM:
     """Interface for interacting with FONA 2G GSM modems.
     """
-    def __init__(self, fona, apn, debug=True):
+    def __init__(self, fona, apn):
         """Initializes interface with 2G GSM modem.
-        :param adafruit_fona fona: Adafruit FONA module.
+        :param adafruit_fona fona: The Adafruit FONA module we are using.
         :param tuple apn: Tuple containing APN name, (optional) APN username,
                             and APN password.
-        :param bool debug: Enable verbose debug output.
 
         """
         self._iface = fona
-        self._debug = debug
         self._apn = apn
         self._gsm_connected = False
 
@@ -69,9 +67,8 @@ class GSM:
     def is_attached(self):
         """Returns if the modem is attached to the network
         and the GPS has a fix."""
-        if self._iface.gps == 3:
-            if self._iface.network_status == 1:
-                return True
+        if self._iface.gps == 3 and self._iface.network_status == 1:
+            return True
         return False
 
 

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -68,13 +68,16 @@ class GSM:
     def is_connected(self):
         """Returns if attached to GSM and an IP Addresss was obtained.
         """
-        return self._gsm_connected
+        if not self._gsm_connected:
+            return False
+        return True
 
     def connect(self):
         """Connect to GSM network
 
         """
-        if not self._iface.set_gprs(self._apn, True):
+        if self._iface.set_gprs(self._apn, True):
+            self._gsm_connected = True
+        else:
             # reset context for next connection attempt
             self._iface.set_gprs(self._apn, False)
-        self._gsm_connected = True

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -41,6 +41,7 @@ class GSM:
         """
         self._iface = fona
         self._debug = debug
+        self._apn = apn
 
         # Attempt to enable GPS module and obtain GPS fix
         attempts = 10
@@ -61,32 +62,26 @@ class GSM:
             attempts -= 1
             time.sleep(1)
 
-        # Set GPRS
-        attempts = 5
-        while not self._iface.set_gprs(apn, True):
-            if attempts == 0:
-                raise RuntimeError("Unable to establish PDP context.")
-            if self._debug:
-                print("* Unable to bringup network, retrying, ", attempts)
-            self._iface.set_gprs(apn, False)
-            attempts -= 1
-            time.sleep(5)
-
-        # Query local IP
-        if not self._iface.local_ip:
-            raise RuntimeError("Unable to obtain module IP address.")
 
     @property
     def is_connected(self):
         """Returns if attached to GPRS and an IP Addresss was obtained.
         """
+        self._iface.local_ip
         if not self._iface.gprs and self._iface.local_ip:
             return False
         return True
 
-    def connect(self):
+    def connect(self, attempts=5):
         """Connect to GPRS network
-        """
-        # TODO
-        pass
+        :param int attempts: Amount of attempts to connect to GSM network.
 
+        """
+        while not self._iface.set_gprs(self._apn, True):
+            if attempts == 0:
+                raise RuntimeError("Unable to establish PDP context.")
+            if self._debug:
+                print("* Unable to bringup network, retrying, ", attempts)
+            self._iface.set_gprs(self._apn, False)
+            attempts -= 1
+            time.sleep(5)

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -73,8 +73,8 @@ class GSM:
             time.sleep(5)
 
         # Query local IP
-        # TODO
-        print("IP: ", self._iface.local_ip)
+        if not self._iface.local_ip:
+            raise RuntimeError("Unable to obtain module IP address.")
 
     def network_attached(self):
         """Returns if modem is attached to cellular network."""

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -28,11 +28,12 @@ Interface for 2G GSM cellular modems such as the Adafruit FONA808.
 * Author(s): Brent Rubell
 
 """
-import time
+
 
 class GSM:
     """Interface for interacting with FONA 2G GSM modems.
     """
+
     def __init__(self, fona, apn):
         """Initializes interface with 2G GSM modem.
         :param adafruit_fona fona: The Adafruit FONA module we are using.
@@ -50,7 +51,7 @@ class GSM:
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.disconnect()
 
     @property
@@ -70,7 +71,6 @@ class GSM:
         if self._iface.gps == 3 and self._iface.network_status == 1:
             return True
         return False
-
 
     @property
     def is_connected(self):

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -42,6 +42,7 @@ class GSM:
         self._iface = fona
         self._debug = debug
         self._apn = apn
+        self._gsm_connected = False
 
         # Attempt to enable GPS module and obtain GPS fix
         attempts = 10
@@ -65,23 +66,15 @@ class GSM:
 
     @property
     def is_connected(self):
-        """Returns if attached to GPRS and an IP Addresss was obtained.
+        """Returns if attached to GSM and an IP Addresss was obtained.
         """
-        self._iface.local_ip
-        if not self._iface.gprs and self._iface.local_ip:
-            return False
-        return True
+        return self._gsm_connected
 
-    def connect(self, attempts=5):
-        """Connect to GPRS network
-        :param int attempts: Amount of attempts to connect to GSM network.
+    def connect(self):
+        """Connect to GSM network
 
         """
-        while not self._iface.set_gprs(self._apn, True):
-            if attempts == 0:
-                raise RuntimeError("Unable to establish PDP context.")
-            if self._debug:
-                print("* Unable to bringup network, retrying, ", attempts)
+        if not self._iface.set_gprs(self._apn, True):
+            # reset context for next connection attempt
             self._iface.set_gprs(self._apn, False)
-            attempts -= 1
-            time.sleep(5)
+        self._gsm_connected = True

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -65,6 +65,21 @@ class GSM:
             attempts -= 1
             time.sleep(1)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.disconnect()
+
+    @property
+    def imei(self):
+        """Returns the GSM modem's IEMI number, as a string."""
+        return self._iface.iemi
+
+    @property
+    def iccid(self):
+        """Returns the SIM card's ICCID, as a string."""
+        return self._iface.iccid
 
     @property
     def is_connected(self):
@@ -77,11 +92,14 @@ class GSM:
         return True
 
     def connect(self):
-        """Connect to GSM network
-
-        """
+        """Connect to GSM network."""
         if self._iface.set_gprs(self._apn, True):
             self._gsm_connected = True
         else:
             # reset context for next connection attempt
             self._iface.set_gprs(self._apn, False)
+
+    def disconnect(self):
+        """Disconnect from GSM network."""
+        self._iface.set_gprs(self._apn, False)
+        self._gsm_connected = False

--- a/adafruit_fona/adafruit_fona_gsm.py
+++ b/adafruit_fona/adafruit_fona_gsm.py
@@ -31,9 +31,11 @@ Interface for 2G GSM cellular modems such as the Adafruit FONA808.
 import time
 
 class GSM:
+    """Interface for interacting with FONA 2G GSM modems.
+    """
     def __init__(self, fona, apn, debug=True):
         """Initializes interface with 2G GSM modem.
-        :param adafruit_fona fona: Adafruit FONA module. 
+        :param adafruit_fona fona: Adafruit FONA module.
         :param tuple apn: Tuple containing APN name, (optional) APN username,
                             and APN password.
         :param bool debug: Enable verbose debug output.
@@ -66,7 +68,9 @@ class GSM:
 
     @property
     def is_connected(self):
-        """Returns if attached to GSM and an IP Addresss was obtained.
+        """Returns if attached to GSM
+        and an IP Addresss was obtained.
+
         """
         if not self._gsm_connected:
             return False

--- a/examples/fona_aio_post.py
+++ b/examples/fona_aio_post.py
@@ -23,9 +23,6 @@ rst = digitalio.DigitalInOut(board.D4)
 # Initialize FONA module (this may take a few seconds)
 fona = FONA(uart, rst)
 
-# Enable FONA debugging
-fona._debug = True
-
 # initialize gsm
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 

--- a/examples/fona_aio_post.py
+++ b/examples/fona_aio_post.py
@@ -3,6 +3,7 @@ import board
 import busio
 import digitalio
 from adafruit_fona.adafruit_fona import FONA
+from adafruit_fona.adafruit_fona_gsm import GSM
 import adafruit_fona.adafruit_fona_socket as cellular_socket
 import adafruit_requests as requests
 
@@ -20,18 +21,18 @@ uart = busio.UART(board.TX, board.RX, baudrate=4800)
 rst = digitalio.DigitalInOut(board.D4)
 
 # Initialize FONA module (this may take a few seconds)
-print("Initializing FONA")
 fona = FONA(uart, rst)
 
-# Enable GPS
-fona.gps = True
+# Enable FONA debugging
+fona._debug = True
 
-# Bring up cellular connection
-fona.configure_gprs((secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
+# initialize gsm
+gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
-# Bring up GPRS
-fona.gprs = True
-print("FONA initialized")
+while not gsm.is_connected:
+    print("Connecting to network...")
+    gsm.connect()
+    time.sleep(5)
 
 # Initialize a requests object with a socket and cellular interface
 requests.set_socket(cellular_socket, fona)

--- a/examples/fona_aio_post.py
+++ b/examples/fona_aio_post.py
@@ -29,6 +29,10 @@ fona._debug = True
 # initialize gsm
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
+while not gsm.is_attached:
+    print("Attaching to network...")
+    time.sleep(0.5)
+
 while not gsm.is_connected:
     print("Connecting to network...")
     gsm.connect()

--- a/examples/fona_cheerlights.py
+++ b/examples/fona_cheerlights.py
@@ -3,11 +3,13 @@ import board
 import busio
 import digitalio
 from adafruit_fona.adafruit_fona import FONA
+from adafruit_fona.adafruit_fona_gsm import GSM
 import adafruit_fona.adafruit_fona_socket as cellular_socket
 import adafruit_requests as requests
 
 import neopixel
 import adafruit_fancyled.adafruit_fancyled as fancy
+
 
 # Get GPRS details and more from a secrets.py file
 try:
@@ -23,18 +25,18 @@ uart = busio.UART(board.TX, board.RX, baudrate=4800)
 rst = digitalio.DigitalInOut(board.D4)
 
 # Initialize FONA module (this may take a few seconds)
-print("Initializing FONA")
 fona = FONA(uart, rst)
 
-# Enable GPS
-fona.gps = True
+# Enable FONA debugging
+fona._debug = True
 
-# Bring up cellular connection
-fona.configure_gprs((secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
+# initialize gsm
+gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
-# Bring up GPRS
-fona.gprs = True
-print("FONA initialized")
+while not gsm.is_connected:
+    print("Connecting to network...")
+    gsm.connect()
+    time.sleep(5)
 
 # Initialize a requests object with a socket and cellular interface
 requests.set_socket(cellular_socket, fona)

--- a/examples/fona_cheerlights.py
+++ b/examples/fona_cheerlights.py
@@ -27,9 +27,6 @@ rst = digitalio.DigitalInOut(board.D4)
 # Initialize FONA module (this may take a few seconds)
 fona = FONA(uart, rst)
 
-# Enable FONA debugging
-fona._debug = True
-
 # initialize gsm
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 

--- a/examples/fona_cheerlights.py
+++ b/examples/fona_cheerlights.py
@@ -33,6 +33,10 @@ fona._debug = True
 # initialize gsm
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
+while not gsm.is_attached:
+    print("Attaching to network...")
+    time.sleep(0.5)
+
 while not gsm.is_connected:
     print("Connecting to network...")
     gsm.connect()

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -34,6 +34,10 @@ fona._debug = True
 # initialize gsm
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
+while not gsm.is_attached:
+    print("Attaching to network...")
+    time.sleep(0.5)
+
 while not gsm.is_connected:
     print("Connecting to network...")
     gsm.connect()

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -2,6 +2,7 @@ import board
 import busio
 import digitalio
 from adafruit_fona.adafruit_fona import FONA
+from adafruit_fona.adafruit_fona_gsm import GSM
 import adafruit_fona.adafruit_fona_socket as cellular_socket
 import adafruit_requests as requests
 
@@ -26,35 +27,12 @@ rst = digitalio.DigitalInOut(board.D4)
 # Initialize FONA module (this may take a few seconds)
 fona = FONA(uart, rst)
 
-# Enable GPS
-fona.gps = True
+# Enable FONA debugging
+fona._debug = True
 
-# Bring up cellular connection
-fona.configure_gprs((secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
+# Enable GSM 
+gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
-# Bring up GPRS
-fona.gprs = True
-
-# Initialize a requests object with a socket and cellular interface
-requests.set_socket(cellular_socket, fona)
 
 print("My IP address is:", fona.local_ip)
 print("IP lookup adafruit.com: %s" % fona.get_host_by_name("adafruit.com"))
-
-# fona._debug = True
-print("Fetching text from", TEXT_URL)
-r = requests.get(TEXT_URL)
-print("-" * 40)
-print(r.text)
-print("-" * 40)
-r.close()
-
-print()
-print("Fetching json from", JSON_URL)
-r = requests.get(JSON_URL)
-print("-" * 40)
-print(r.json())
-print("-" * 40)
-r.close()
-
-print("Done!")

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -34,5 +34,5 @@ fona._debug = True
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
 
-print("My IP address is:", fona.local_ip)
-print("IP lookup adafruit.com: %s" % fona.get_host_by_name("adafruit.com"))
+# print("My IP address is:", fona.local_ip)
+# print("IP lookup adafruit.com: %s" % fona.get_host_by_name("adafruit.com"))

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -28,9 +28,6 @@ rst = digitalio.DigitalInOut(board.D4)
 # Initialize FONA module (this may take a few seconds)
 fona = FONA(uart, rst)
 
-# Enable FONA debugging
-fona._debug = True
-
 # initialize gsm
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -39,4 +39,26 @@ while not gsm.is_connected:
     gsm.connect()
     time.sleep(5)
 
-print("connected!")
+print("My IP address is:", fona.local_ip)
+print("IP lookup adafruit.com: %s" % fona.get_host_by_name("adafruit.com"))
+
+# Initialize a requests object with a socket and cellular interface
+requests.set_socket(cellular_socket, fona)
+
+# fona._debug = True
+print("Fetching text from", TEXT_URL)
+r = requests.get(TEXT_URL)
+print("-" * 40)
+print(r.text)
+print("-" * 40)
+r.close()
+
+print()
+print("Fetching json from", JSON_URL)
+r = requests.get(JSON_URL)
+print("-" * 40)
+print(r.json())
+print("-" * 40)
+r.close()
+
+print("Done!")

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -32,5 +32,6 @@ fona._debug = True
 
 # Enable GSM 
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
+gsm.connect()
 
 print(gsm.is_connected)

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -33,6 +33,4 @@ fona._debug = True
 # Enable GSM 
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
 
-
-# print("My IP address is:", fona.local_ip)
-# print("IP lookup adafruit.com: %s" % fona.get_host_by_name("adafruit.com"))
+print(gsm.is_connected)

--- a/examples/fona_simpletest.py
+++ b/examples/fona_simpletest.py
@@ -1,3 +1,4 @@
+import time
 import board
 import busio
 import digitalio
@@ -30,8 +31,12 @@ fona = FONA(uart, rst)
 # Enable FONA debugging
 fona._debug = True
 
-# Enable GSM 
+# initialize gsm
 gsm = GSM(fona, (secrets["apn"], secrets["apn_username"], secrets["apn_password"]))
-gsm.connect()
 
-print(gsm.is_connected)
+while not gsm.is_connected:
+    print("Connecting to network...")
+    gsm.connect()
+    time.sleep(5)
+
+print("connected!")


### PR DESCRIPTION
This release adds:

**Compatibility**
* with CircuitPython_MiniMQTT, CircuitPython_Requests

**Methods**
* `reset`: performs a hardware reset on the modem
* `factory_reset`: factory reset modem
* `icccid`: rets. sim card's iccid number
* `unpretty_ip`

**Modules**
* `adafruit_fona_gsm`: Class for interfacing with 2G GSM modems (FONA808+GPS), 
  * Simpler user-code for attaching to, bringing up, and disconnecting GSM modem.
  * Network connection and error handling is now handled from user-code instead of within the module (polling similar to ESP32SPI's `wifimanager`)

Examples have been modified to reflect the release.

NOTE: This release does **not** support TCP client connections over SSL.