### PR TITLE
Add SMS Example

### DIFF
--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -41,7 +41,7 @@ import time
 from micropython import const
 from simpleio import map_range
 
-__version__ = "1.1.0"
+__version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FONA.git"
 
 # pylint: disable=bad-whitespace

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -41,7 +41,7 @@ import time
 from micropython import const
 from simpleio import map_range
 
-__version__ = "0.0.0-auto.0"
+__version__ = "1.1.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_FONA.git"
 
 # pylint: disable=bad-whitespace
@@ -177,20 +177,8 @@ class FONA:
     @property
     # pylint: disable=too-many-return-statements
     def version(self):
-        """Returns FONA Version, as a string."""
-        if self._fona_type == FONA_800_L:
-            return "FONA 800L"
-        if self._fona_type == FONA_800_H:
-            return "FONA 800H"
-        if self._fona_type == FONA_808_V1:
-            return "FONA 808 (v1)"
-        if self._fona_type == FONA_808_V2:
-            return "FONA 808 (v2)"
-        if self._fona_type == FONA_3G_A:
-            return "FONA 3G (US)"
-        if self._fona_type == FONA_3G_E:
-            return "FONA 3G (EU)"
-        return -1
+        """Returns FONA Version."""
+        return self._fona_type
 
     @property
     def iemi(self):
@@ -466,6 +454,28 @@ class FONA:
         return bytes(octets)
 
     ### SMS ###
+
+    def available(self):
+        """Returns bytes in the in the input buffer avaliable to be read"""
+        return self._uart.in_waiting
+
+    @property
+    def enable_sms_notification(self):
+        """Returns status of new SMS message notifications"""
+        if not self._send_parse_reply(b"AT+CNMI?\r\n", b"+CNMI:", idx=1):
+            return False
+        return self._buf
+
+    @enable_sms_notification.setter
+    def enable_sms_notification(self, enable=True):
+        """Enables or disables new SMS message notifications."""
+        if enable:
+            if not self._send_check_reply(b"AT+CNMI=2,1\r\n", reply=REPLY_OK):
+                return False
+        else:
+            if not self._send_check_reply(b"AT+CNMI=2,0\r\n", reply=REPLY_OK):
+                return False
+        return True
 
     def send_sms(self, phone_number, message):
         """Sends a message SMS to a phone number.

--- a/adafruit_fona/adafruit_fona.py
+++ b/adafruit_fona/adafruit_fona.py
@@ -597,7 +597,7 @@ class FONA:
         self._uart.readinto(self._buf)
         message = bytes(self._buf).decode()
         self._uart.reset_input_buffer()
-        self.read_line() # eat 'OK'
+        self.read_line()  # eat 'OK'
 
         return sender, message
 

--- a/examples/fona_sms_response.py
+++ b/examples/fona_sms_response.py
@@ -28,8 +28,8 @@ notification_buf = bytearray(64)
 
 print("FONA Ready!")
 while True:
-    if fona.in_waiting: # data is available from FONA
-        notification_buf = fona._read_line()[1]
+    if fona.in_waiting:  # data is available from FONA
+        notification_buf = fona.read_line()[1]
         # Split out the sms notification slot num.
         notification_buf = notification_buf.decode()
         sms_slot = notification_buf.split(",")[1]

--- a/examples/fona_sms_response.py
+++ b/examples/fona_sms_response.py
@@ -1,0 +1,45 @@
+import time
+import board
+import busio
+import digitalio
+from adafruit_fona.adafruit_fona import FONA
+
+print("FONA SMS Response")
+
+# Create a serial connection for the FONA connection
+uart = busio.UART(board.TX, board.RX)
+rst = digitalio.DigitalInOut(board.D5)
+
+# Initialize FONA module (this may take a few seconds)
+fona = FONA(uart, rst)
+
+# Enable FONA debug output
+fona.debug=True
+
+# Initialize Network
+while fona.network_status != 1:
+    print("Connecting to network...")
+    time.sleep(1)
+print("Connected to network!")
+print("RSSI: %ddB" % fona.rssi)
+
+# Enable FONA SMS notification
+fona.enable_sms_notification = True
+
+# store incoming notification info
+notification_buf = bytearray(64)
+
+print("FONA Ready!")
+while True:
+    if fona.in_waiting: # data is available from FONA
+        notification_buf = fona._read_line()[1]
+        # Split out the sms notification slot num.
+        notification_buf = notification_buf.decode()
+        sms_slot = notification_buf.split(",")[1]
+
+        print("NEW SMS!\n\t Slot: ", sms_slot)
+
+        # Get sms message and address
+        sender, message = fona.read_sms(sms_slot)
+        print("FROM: ", sender)
+        print("MSG: ", message)

--- a/examples/fona_sms_response.py
+++ b/examples/fona_sms_response.py
@@ -8,7 +8,7 @@ print("FONA SMS Response")
 
 # Create a serial connection for the FONA connection
 uart = busio.UART(board.TX, board.RX)
-rst = digitalio.DigitalInOut(board.D5)
+rst = digitalio.DigitalInOut(board.D4)
 
 # Initialize FONA module (this may take a few seconds)
 fona = FONA(uart, rst, debug=True)

--- a/examples/fona_sms_response.py
+++ b/examples/fona_sms_response.py
@@ -11,10 +11,7 @@ uart = busio.UART(board.TX, board.RX)
 rst = digitalio.DigitalInOut(board.D5)
 
 # Initialize FONA module (this may take a few seconds)
-fona = FONA(uart, rst)
-
-# Enable FONA debug output
-fona.debug=True
+fona = FONA(uart, rst, debug=True)
 
 # Initialize Network
 while fona.network_status != 1:
@@ -43,3 +40,14 @@ while True:
         sender, message = fona.read_sms(sms_slot)
         print("FROM: ", sender)
         print("MSG: ", message)
+
+        # Reply back!
+        print("Sending response...")
+        if not fona.send_sms(int(sender), "Hey, I got your text!"):
+            print("SMS Send Failed")
+        print("SMS Sent!")
+
+        # Delete the original message
+        if not fona.delete_sms(sms_slot):
+            print("Could not delete SMS in slot", sms_slot)
+        print("OK!")


### PR DESCRIPTION
This pull request adds:
* `fona_sms_response.py`: Example which waits for a SMS message from the FONA, reads it out and replies back to the sender. Similar to [FONA_SMS_Response.ino in the arduino fona library](https://github.com/adafruit/Adafruit_FONA/blob/master/examples/FONA_SMS_Response/FONA_SMS_Response.ino).
* `fona.enable_sms_notification`: Getter/setter properties for FONA sms notification command
* `fona.in_waiting`: Returns number of bytes available to be read from the uart (https://circuitpython.readthedocs.io/en/latest/shared-bindings/busio/UART.html#busio.UART.in_waiting)
* Makes `fona.read_line()` a public method