### PR TITLE
change setup.py to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(
     # simple. Or you can use find_packages().
     # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
     #       CHANGE `py_modules=['...']` TO `packages=['...']`
-    py_modules=["adafruit_fona"],
+    packages=["adafruit_fona"],
 )


### PR DESCRIPTION
I don't have the real hardware to test with. But I did test with `pip install .` and it does successfully let me get past the `no module named 'Adafruit_fona'` error mentioned in #9.